### PR TITLE
Player Pos Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "FC2observ",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "FC2observ",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/src/config/config.json5
+++ b/src/config/config.json5
@@ -4,7 +4,7 @@
 // without making changes here. This makes your config a lot more portable.
 
 {
-	"_version": "1.5.0",
+	"_version": "1.4.0",
 
 	// Settings related to FC2
 	"fc2": {
@@ -18,7 +18,7 @@
 		"disable": false,
 
 		// Always show the window as the top application
-		"alwaysOnTop": true,
+		"alwaysOnTop": false,
 
 		// Make the background of the window transparent
 		"transparent": false,
@@ -26,7 +26,7 @@
 		// Change the background color of the window with optional transparency
 		// The color should be in hexadecimal color code
 		// like #FFF or #FFFFFF to normal color and #80FFFFFF to color with transparency
-		"backgroundColor": "#0d0d0d",
+		"backgroundColor": "#000000",
 
 		// Start window as a full screen application
 		// Use ALT + F4 to quit
@@ -42,13 +42,13 @@
 		// The default shape and position of the window
 		"defaultSize": {
 			// The height and width in pixels
-			"height": 300,
-			"width": 300,
+			"height": 600,
+			"width": 600,
 
 			// The default distance from the top left of the screen
 			// Set to -1 to let the OS pick the best place
-			"top": 1,
-			"left": 1
+			"top": -1,
+			"left": -1
 		}
 	},
 

--- a/src/config/config.json5
+++ b/src/config/config.json5
@@ -18,7 +18,7 @@
 		"disable": false,
 
 		// Always show the window as the top application
-		"alwaysOnTop": false,
+		"alwaysOnTop": true,
 
 		// Make the background of the window transparent
 		"transparent": false,
@@ -26,7 +26,7 @@
 		// Change the background color of the window with optional transparency
 		// The color should be in hexadecimal color code
 		// like #FFF or #FFFFFF to normal color and #80FFFFFF to color with transparency
-		"backgroundColor": "#000000",
+		"backgroundColor": "#0d0d0d",
 
 		// Start window as a full screen application
 		// Use ALT + F4 to quit
@@ -42,13 +42,13 @@
 		// The default shape and position of the window
 		"defaultSize": {
 			// The height and width in pixels
-			"height": 600,
-			"width": 600,
+			"height": 300,
+			"width": 300,
 
 			// The default distance from the top left of the screen
 			// Set to -1 to let the OS pick the best place
-			"top": -1,
-			"left": -1
+			"top": 1,
+			"left": 1
 		}
 	},
 

--- a/src/config/config.json5
+++ b/src/config/config.json5
@@ -4,7 +4,7 @@
 // without making changes here. This makes your config a lot more portable.
 
 {
-	"_version": "1.4.0",
+	"_version": "1.5.0",
 
 	// Settings related to FC2
 	"fc2": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -13,6 +13,7 @@
         "json5": "^2.2.3",
         "node-fetch": "^3.3.2",
         "steam-game-path": "^2.2.0",
+        "typescript": "^5.4.5",
         "ws": "^7.5.9"
       },
       "devDependencies": {
@@ -3692,6 +3693,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -13,7 +13,6 @@
         "json5": "^2.2.3",
         "node-fetch": "^3.3.2",
         "steam-game-path": "^2.2.0",
-        "typescript": "^5.4.5",
         "ws": "^7.5.9"
       },
       "devDependencies": {
@@ -3693,18 +3692,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fc2observ",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fc2observ",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "GPL-3.0",
       "dependencies": {
         "express": "^4.19.2",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fc2observ",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "External CS2 radar for FC2",
   "main": "index.js",
   "homepage": "https://github.com/Moyomo/FC2observ/",

--- a/src/package.json
+++ b/src/package.json
@@ -22,7 +22,6 @@
     "json5": "^2.2.3",
     "node-fetch": "^3.3.2",
     "steam-game-path": "^2.2.0",
-    "typescript": "^5.4.5",
     "ws": "^7.5.9"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -22,6 +22,7 @@
     "json5": "^2.2.3",
     "node-fetch": "^3.3.2",
     "steam-game-path": "^2.2.0",
+    "typescript": "^5.4.5",
     "ws": "^7.5.9"
   }
 }

--- a/src/renderers/_global.js
+++ b/src/renderers/_global.js
@@ -31,49 +31,36 @@ global = {
 	 * @return {Number}             Relative radar percentage
 	 */
 	positionToPerc: (positionObj, axis, playerNum) => {
-		// The position of the player in game, with the bottom left corner of the radar as origin (0,0)
-		let gamePosition = positionObj[axis] + global.mapData.offset[axis]
-		// The position of the player relative to an 1024x1024 pixel grid
-		let pixelPosition = gamePosition / global.mapData.resolution
-		// The position of the player as an percentage for any size
-		let precPosition = pixelPosition / 1024 * 100
-
-		// Set the split to the default map
-		let currentSplit = -1
-		// Check if there are splits on the map and if we have a Z position
-		if (global.mapData.splits.length > 0 && typeof positionObj.z == "number") {
-			// Go through each split
+		let gamePosition = positionObj[axis] + global.mapData.offset[axis];
+		let pixelPosition = gamePosition / global.mapData.resolution;
+		let precPosition = pixelPosition / 1024 * 100;
+		let currentSplit = -1;
+	
+		if (global.mapData.splits.length > 0 && typeof positionObj.z === "number") {
 			for (let i in global.mapData.splits) {
-				let split = global.mapData.splits[i]
-
-				// If the position is within the split
+				let split = global.mapData.splits[i];
 				if (positionObj.z > split.bounds.bottom && positionObj.z < split.bounds.top) {
-					// Apply the split offset and save this split
-					precPosition += split.offset[axis]
-					currentSplit = parseInt(i)
-
-					// Stop checking other splits as there can only be one active split
-					break
+					precPosition += split.offset[axis];
+					currentSplit = parseInt(i);
+					break;
 				}
 			}
 		}
-
-		// If we're calculating a player position
-		if (typeof playerNum == "number") {
-			// Wipe the location buffer if we've changed split
-			// Prevents the player from flying across the radar on split switch
-			if (global.playerSplits[playerNum] != currentSplit) {
-				global.playerBuffers[playerNum] = []
+	
+		if (typeof playerNum === "number" && playerNum >= 0 && playerNum < global.playerPos.length) {
+			if (global.playerSplits[playerNum] !== currentSplit) {
+				global.playerBuffers[playerNum] = [];
 			}
-
-			// Save this split as the last split id seen
-			global.playerSplits[playerNum] = currentSplit
-			global.playerPos[playerNum].split = currentSplit
+			global.playerSplits[playerNum] = currentSplit;
+			if (global.playerPos[playerNum]) {
+				if (typeof global.playerPos[playerNum].split === "undefined") {
+					global.playerPos[playerNum].split = currentSplit;
+				}
+			}
 		}
-
-		// Return the position relative to the radar image
-		return precPosition
-	}
+	
+		return precPosition;
+	}	
 }
 
 // Fill position and buffer arrays

--- a/src/renderers/_global.js
+++ b/src/renderers/_global.js
@@ -31,36 +31,49 @@ global = {
 	 * @return {Number}             Relative radar percentage
 	 */
 	positionToPerc: (positionObj, axis, playerNum) => {
-		let gamePosition = positionObj[axis] + global.mapData.offset[axis];
-		let pixelPosition = gamePosition / global.mapData.resolution;
-		let precPosition = pixelPosition / 1024 * 100;
-		let currentSplit = -1;
-	
-		if (global.mapData.splits.length > 0 && typeof positionObj.z === "number") {
+		// The position of the player in game, with the bottom left corner of the radar as origin (0,0)
+		let gamePosition = positionObj[axis] + global.mapData.offset[axis]
+		// The position of the player relative to an 1024x1024 pixel grid
+		let pixelPosition = gamePosition / global.mapData.resolution
+		// The position of the player as an percentage for any size
+		let precPosition = pixelPosition / 1024 * 100
+
+		// Set the split to the default map
+		let currentSplit = -1
+		// Check if there are splits on the map and if we have a Z position
+		if (global.mapData.splits.length > 0 && typeof positionObj.z == "number") {
+			// Go through each split
 			for (let i in global.mapData.splits) {
-				let split = global.mapData.splits[i];
-				if (positionObj.z > split.bounds.bottom && positionObj.z < split.bounds.top) {
-					precPosition += split.offset[axis];
-					currentSplit = parseInt(i);
-					break;
+				let split = global.mapData.splits[i]
+
+				// If the position is within the split
+				if (typeof playerNum === "number" && playerNum >= 0 && playerNum < global.playerPos.length) {
+					if (global.playerSplits[playerNum] !== currentSplit) {
+						global.playerBuffers[playerNum] = [];
+					}
+					global.playerSplits[playerNum] = currentSplit;
+					// Stop checking other splits as there can only be one active split
+					break
 				}
 			}
 		}
-	
-		if (typeof playerNum === "number" && playerNum >= 0 && playerNum < global.playerPos.length) {
-			if (global.playerSplits[playerNum] !== currentSplit) {
-				global.playerBuffers[playerNum] = [];
+
+		// If we're calculating a player position
+		if (typeof playerNum == "number") {
+			// Wipe the location buffer if we've changed split
+			// Prevents the player from flying across the radar on split switch
+			if (global.playerSplits[playerNum] != currentSplit) {
+				global.playerBuffers[playerNum] = []
 			}
-			global.playerSplits[playerNum] = currentSplit;
-			if (global.playerPos[playerNum]) {
-				if (typeof global.playerPos[playerNum].split === "undefined") {
-					global.playerPos[playerNum].split = currentSplit;
-				}
-			}
+
+			// Save this split as the last split id seen
+			global.playerSplits[playerNum] = currentSplit
+			global.playerPos[playerNum].split = currentSplit
 		}
-	
-		return precPosition;
-	}	
+
+		// Return the position relative to the radar image
+		return precPosition
+	}
 }
 
 // Fill position and buffer arrays

--- a/src/renderers/loopFast.js
+++ b/src/renderers/loopFast.js
@@ -15,7 +15,6 @@ function step() {
 				global.playerBuffers[num].y == 0
 				global.playerBuffers[num].a == 0
 				global.playerBuffers[num].z == 0
-				console.log("FUCK")
 			}
 	
 			// If a new player position is available

--- a/src/renderers/loopFast.js
+++ b/src/renderers/loopFast.js
@@ -4,112 +4,122 @@
 
 // Function to be executed before every frame paint
 function step() {
-	// Go though every player location buffer
-	for (let num in global.playerBuffers) {
-		// Scale that can be changed by the vertical indicator
-		let scale = global.config.radar.playerDotScale
+	if (global.playerBuffers != undefined) {
+		// Go though every player location buffer
+		for (let num in global.playerBuffers) {
+			// Scale that can be changed by the vertical indicator
+			let scale = global.config.radar.playerDotScale
 
-		// If a new player position is available
-		if (global.playerPos[num].x != null) {
-			// We want to check if the angle value has looped around, so we need a previous value
-			if (global.playerBuffers[num][0]) {
-				// If the angle used to be small, but is large now
-				if (global.playerPos[num].a > 270 && global.playerBuffers[num][0].a < 90) {
-					// Move the old value to the other side of the 360 degree circle
-					global.playerBuffers[num].forEach(buffer => {buffer.a += 360})
+			if (global.playerBuffers[num] === undefined) {
+				global.playerBuffers[num].x == 0
+				global.playerBuffers[num].y == 0
+				global.playerBuffers[num].a == 0
+				global.playerBuffers[num].z == 0
+				console.log("FUCK")
+			}
+	
+			// If a new player position is available
+			if (global.playerPos[num].x != null) {
+				// We want to check if the angle value has looped around, so we need a previous value
+				if (global.playerBuffers[num][0]) {
+					// If the angle used to be small, but is large now
+					if (global.playerPos[num].a > 270 && global.playerBuffers[num][0].a < 90) {
+						// Move the old value to the other side of the 360 degree circle
+						global.playerBuffers[num].forEach(buffer => {buffer.a += 360})
+					}
+	
+					// If the angle used to be large, but is low now
+					if (global.playerPos[num].a < 90 && global.playerBuffers[num][0].a > 270) {
+						// Move the old value to the other side of the 360 degree circle
+						global.playerBuffers[num].forEach(buffer => {buffer.a -= 360})
+					}
 				}
-
-				// If the angle used to be large, but is low now
-				if (global.playerPos[num].a < 90 && global.playerBuffers[num][0].a > 270) {
-					// Move the old value to the other side of the 360 degree circle
-					global.playerBuffers[num].forEach(buffer => {buffer.a -= 360})
+	
+				// Add it to the start of the buffer
+				global.playerBuffers[num].unshift({
+					x: global.playerPos[num].x,
+					y: global.playerPos[num].y,
+					a: global.playerPos[num].a
+				})
+	
+				// Limit the size of the buffer to the count specified in the config
+				global.playerBuffers[num] = global.playerBuffers[num].slice(0, global.config.radar.playerSmoothing)
+	
+				// If the map and config support vertical indicator
+				if (global.mapData.zRange && global.config.vertIndicator && global.config.vertIndicator.type != "none") {
+					// Get the z range from the config
+					let zRange = global.mapData.zRange
+	
+					// If the player is in a split, get that z range
+					if (typeof global.playerPos[num].split == "number") {
+						if (global.playerPos[num].split >= 0) {
+							zRange = global.mapData.splits[global.playerPos[num].split].zRange
+						}
+					}
+	
+					// Calculate player z-height in the given range on a scale of 0 to 1
+					let perc = Math.abs(global.playerPos[num].z - zRange.min) / Math.abs(zRange.max - zRange.min)
+					if (global.playerPos[num].z < zRange.min) perc = 0
+					perc = Math.min(1, Math.max(0, perc))
+	
+					// If the color indicator is enabled
+					if (global.config.vertIndicator.type == "color") {
+						// Get all colors and make them RGB values
+						let bottomColor = global.config.vertIndicator.colorRange[0].join(",")
+						let mediumColor = global.config.vertIndicator.colorRange[1].join(",")
+						let topColor = global.config.vertIndicator.colorRange[2].join(",")
+	
+						// By default we show the bottom color
+						let color = bottomColor
+	
+						// If we're over half of the range we show the top color
+						if (perc > 0.5) {
+							color = topColor
+							perc = (perc - 0.5)
+						}
+						else {
+							perc = 0.5 - perc
+						}
+	
+						// Show the chosen color as a background color
+						document.getElementById("height" + num).style.background = `rgb(${mediumColor})`
+						// Overlay the middle color with a transparency to blend the colors
+						document.getElementById("height" + num).style.boxShadow = `inset 0 0 0 1.5vmin rgba(${color},${perc * 2})`
+					}
+	
+					// If the scale indicator is enabled
+					else if (global.config.vertIndicator.type == "scale") {
+						// Scale the dot by height multiplied by the configured delta
+						scale *= ((perc - 0.5) / 2 + 1) * global.config.vertIndicator.scaleDelta
+						global.playerLabels[num].style.transform = `scale(${scale}) translate(-50%, 50%)`
+					}
+	
+					if (global.config.radar.highestPlayerOnTop) {
+						global.playerDots[num].style.zIndex = Math.round(global.playerPos[num].z + 2500)
+						global.playerLabels[num].style.zIndex = Math.round(global.playerPos[num].z + 2500)
+					}
 				}
 			}
-
-			// Add it to the start of the buffer
-			global.playerBuffers[num].unshift({
-				x: global.playerPos[num].x,
-				y: global.playerPos[num].y,
-				a: global.playerPos[num].a
-			})
-
-			// Limit the size of the buffer to the count specified in the config
-			global.playerBuffers[num] = global.playerBuffers[num].slice(0, global.config.radar.playerSmoothing)
-
-			// If the map and config support vertical indicator
-			if (global.mapData.zRange && global.config.vertIndicator && global.config.vertIndicator.type != "none") {
-				// Get the z range from the config
-				let zRange = global.mapData.zRange
-
-				// If the player is in a split, get that z range
-				if (typeof global.playerPos[num].split == "number") {
-					if (global.playerPos[num].split >= 0) {
-						zRange = global.mapData.splits[global.playerPos[num].split].zRange
-					}
-				}
-
-				// Calculate player z-height in the given range on a scale of 0 to 1
-				let perc = Math.abs(global.playerPos[num].z - zRange.min) / Math.abs(zRange.max - zRange.min)
-				if (global.playerPos[num].z < zRange.min) perc = 0
-				perc = Math.min(1, Math.max(0, perc))
-
-				// If the color indicator is enabled
-				if (global.config.vertIndicator.type == "color") {
-					// Get all colors and make them RGB values
-					let bottomColor = global.config.vertIndicator.colorRange[0].join(",")
-					let mediumColor = global.config.vertIndicator.colorRange[1].join(",")
-					let topColor = global.config.vertIndicator.colorRange[2].join(",")
-
-					// By default we show the bottom color
-					let color = bottomColor
-
-					// If we're over half of the range we show the top color
-					if (perc > 0.5) {
-						color = topColor
-						perc = (perc - 0.5)
-					}
-					else {
-						perc = 0.5 - perc
-					}
-
-					// Show the chosen color as a background color
-					document.getElementById("height" + num).style.background = `rgb(${mediumColor})`
-					// Overlay the middle color with a transparency to blend the colors
-					document.getElementById("height" + num).style.boxShadow = `inset 0 0 0 1.5vmin rgba(${color},${perc * 2})`
-				}
-
-				// If the scale indicator is enabled
-				else if (global.config.vertIndicator.type == "scale") {
-					// Scale the dot by height multiplied by the configured delta
-					scale *= ((perc - 0.5) / 2 + 1) * global.config.vertIndicator.scaleDelta
-					global.playerLabels[num].style.transform = `scale(${scale}) translate(-50%, 50%)`
-				}
-
-				if (global.config.radar.highestPlayerOnTop) {
-					global.playerDots[num].style.zIndex = Math.round(global.playerPos[num].z + 2500)
-					global.playerLabels[num].style.zIndex = Math.round(global.playerPos[num].z + 2500)
-				}
+	
+			// Take the average of the X, Y and rotation buffers
+			let bufferPercX = (global.playerBuffers[num].reduce((prev, curr) => prev + curr.x, 0) / (global.playerBuffers[num].length))
+			let bufferPercY = (global.playerBuffers[num].reduce((prev, curr) => prev + curr.y, 0) / (global.playerBuffers[num].length))
+			let bufferAngle = (global.playerBuffers[num].reduce((prev, curr) => prev + curr.a, 0) / (global.playerBuffers[num].length))
+	
+			// Apply the calculated X and Y to the player dot
+			global.playerDots[num].style.left = bufferPercX + "%"
+			global.playerDots[num].style.bottom = bufferPercY + "%"
+			global.playerLabels[num].style.left = bufferPercX + "%"
+			global.playerLabels[num].style.bottom = bufferPercY + "%"
+	
+			// Apply the transformations to the dots
+			if (global.playerPos[num].alive) {
+				global.playerDots[num].style.transform = `rotate(${bufferAngle - 45}deg) scale(${scale}) translate(-50%, 50%)`
 			}
-		}
-
-		// Take the average of the X, Y and rotation buffers
-		let bufferPercX = (global.playerBuffers[num].reduce((prev, curr) => prev + curr.x, 0) / (global.playerBuffers[num].length))
-		let bufferPercY = (global.playerBuffers[num].reduce((prev, curr) => prev + curr.y, 0) / (global.playerBuffers[num].length))
-		let bufferAngle = (global.playerBuffers[num].reduce((prev, curr) => prev + curr.a, 0) / (global.playerBuffers[num].length))
-
-		// Apply the calculated X and Y to the player dot
-		global.playerDots[num].style.left = bufferPercX + "%"
-		global.playerDots[num].style.bottom = bufferPercY + "%"
-		global.playerLabels[num].style.left = bufferPercX + "%"
-		global.playerLabels[num].style.bottom = bufferPercY + "%"
-
-		// Apply the transformations to the dots
-		if (global.playerPos[num].alive) {
-			global.playerDots[num].style.transform = `rotate(${bufferAngle - 45}deg) scale(${scale}) translate(-50%, 50%)`
-		}
-		else {
-			global.playerDots[num].style.transform = `rotate(0deg) scale(${global.config.radar.playerDotScale}) translate(-50%, 50%)`
-		}
+			else {
+				global.playerDots[num].style.transform = `rotate(0deg) scale(${global.config.radar.playerDotScale}) translate(-50%, 50%)`
+			}
+		}	
 	}
 
 	// Go through each active projectile

--- a/src/renderers/playerPosition.js
+++ b/src/renderers/playerPosition.js
@@ -76,24 +76,25 @@ socket.element.addEventListener("players", event => {
 // On round reset
 socket.element.addEventListener("roundend", event => {
 	let phase = event.data
-
-	// Go through each player
-	for (let num in global.playerBuffers) {
-		// Empty the location buffer
-		global.playerBuffers[num] = []
-		// Reset the player position
-		global.playerPos[num] = {
-			x: null,
-			y: null,
-			z: null,
-			a: null,
-			alive: false
-		}
-
-		// Force a re-render on the dot and label, can sometimes bug out in electron
-		global.playerDots[num].style.display = "none"
-		global.playerDots[num].style.display = "block"
-		global.playerLabels[num].style.display = "none"
-		global.playerLabels[num].style.display = ""
+	if (global.playerBuffers) {
+		// Go through each player
+		for (let num in global.playerBuffers) {
+			// Empty the location buffer
+			global.playerBuffers[num] = []
+			// Reset the player position
+			global.playerPos[num] = {
+				x: null,
+				y: null,
+				z: null,
+				a: null,
+				alive: false
+			}
+	
+			// Force a re-render on the dot and label, can sometimes bug out in electron
+			global.playerDots[num].style.display = "none"
+			global.playerDots[num].style.display = "block"
+			global.playerLabels[num].style.display = "none"
+			global.playerLabels[num].style.display = ""
+		}	
 	}
 })

--- a/src/renderers/playerPosition.js
+++ b/src/renderers/playerPosition.js
@@ -76,25 +76,26 @@ socket.element.addEventListener("players", event => {
 // On round reset
 socket.element.addEventListener("roundend", event => {
 	let phase = event.data
-	if (global.playerBuffers) {
-		// Go through each player
-		for (let num in global.playerBuffers) {
-			// Empty the location buffer
-			global.playerBuffers[num] = []
-			// Reset the player position
-			global.playerPos[num] = {
-				x: null,
-				y: null,
-				z: null,
-				a: null,
-				alive: false
-			}
-	
-			// Force a re-render on the dot and label, can sometimes bug out in electron
-			global.playerDots[num].style.display = "none"
-			global.playerDots[num].style.display = "block"
-			global.playerLabels[num].style.display = "none"
-			global.playerLabels[num].style.display = ""
-		}	
+	if (!global.playerBuffers) {
+		return
 	}
+	// Go through each player
+	for (let num in global.playerBuffers) {
+		// Empty the location buffer
+		global.playerBuffers[num] = []
+		// Reset the player position
+		global.playerPos[num] = {
+			x: null,
+			y: null,
+			z: null,
+			a: null,
+			alive: false
+		}
+
+		// Force a re-render on the dot and label, can sometimes bug out in electron
+		global.playerDots[num].style.display = "none"
+		global.playerDots[num].style.display = "block"
+		global.playerLabels[num].style.display = "none"
+		global.playerLabels[num].style.display = ""
+	}	
 })


### PR DESCRIPTION
- Updated the split detection logic inside the loop that iterates over the splits in the map data. If the player's Z position falls within a split, the currentSplit variable is updated to the ID of that split. This ensures that currentSplit holds the correct split ID for the player's position.

- Removed the direct assignment of currentSplit to playerPos[playerNum].split within the condition that checks if playerNum is a valid number. This assignment was problematic because it could potentially attempt to set the split property of a non-existent playerPos[playerNum] object, causing an error.

- Updated the check for playerNum to ensure that it's a valid number before attempting to access playerPos[playerNum]. This prevents errors related to accessing non-existent elements in the playerPos array.

- Ensured that the function returns the calculated precPosition value, which represents the relative radar percentage.