### PR TITLE
fix(positionToPerc): ensure playerPos is defined before setting split

### DIFF
--- a/src/renderers/_global.js
+++ b/src/renderers/_global.js
@@ -59,16 +59,18 @@ global = {
 		}
 
 		// If we're calculating a player position
-		if (typeof playerNum == "number") {
+		if (typeof playerNum === "number" && playerNum >= 0 && playerNum < global.playerPos.length) {
 			// Wipe the location buffer if we've changed split
 			// Prevents the player from flying across the radar on split switch
-			if (global.playerSplits[playerNum] != currentSplit) {
-				global.playerBuffers[playerNum] = []
-			}
+			if (global.playerPos[playerNum] && typeof global.playerPos[playerNum] === 'object') {
+				if (global.playerSplits[playerNum] != currentSplit) {
+					global.playerBuffers[playerNum] = []
+				}
 
-			// Save this split as the last split id seen
-			global.playerSplits[playerNum] = currentSplit
-			global.playerPos[playerNum].split = currentSplit
+				// Save this split as the last split id seen
+				global.playerSplits[playerNum] = currentSplit
+				global.playerPos[playerNum].split = currentSplit
+			}
 		}
 
 		// Return the position relative to the radar image


### PR DESCRIPTION
# Description
This PR addresses a bug in the `positionToPerc` function where an `"Uncaught TypeError: Cannot set properties of undefined (setting 'split')"` was thrown.
 The error occurred when attempting to set the split property of an undefined object in the `global.playerPos` array.

# Changes Made
- Safety Checks Added: Implemented checks to ensure that `global.playerPos[playerNum]` is defined and is an object before setting the split property.
- Array Bounds Verification: Added checks to confirm that `playerNum` is within the valid range of indices for `global.playerPos`.

# Motivation and Context
During certain gameplay scenarios, where playerNum could exceed the bounds of the global.playerPos array or be unset, the application would crash with a TypeError. This fix prevents such scenarios by ensuring that there is a valid object at the specified index before any modifications are made to its properties.
